### PR TITLE
update fetching cms data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     env:
       CMS_API_KEY: ${{ secrets.CMS_API_KEY }}
       CMS_ENDPOINT: ${{ secrets.CMS_ENDPOINT }}
+      # use only development mode
+      CMS_DRAFT_KEY: ""
       TZ: "Asia/Tokyo"
     steps:
       - uses: actions/checkout@v3

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
   "tabWidth": 2,
   "semi": true,
   "trailingComma": "all",
-  "printWidth": 100,
+  "printWidth": 80,
   "plugins": ["prettier-plugin-svelte"],
   "pluginSearchDirs": ["."],
   "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]

--- a/src/lib/components/Articles.svelte
+++ b/src/lib/components/Articles.svelte
@@ -14,8 +14,15 @@
     {#each articles as article}
       <li>
         <a href={`https://zenn.dev${article.path}`}>
-          <h3 class="article-title"><Fa icon={faExternalLink} /> {article.title}</h3>
-          <p><time datetime={article.published_at}>{formatDate(article.published_at)}</time></p>
+          <h3 class="article-title">
+            <Fa icon={faExternalLink} />
+            {article.title}
+          </h3>
+          <p>
+            <time datetime={article.published_at}
+              >{formatDate(article.published_at)}</time
+            >
+          </p>
         </a>
       </li>
     {/each}

--- a/src/lib/components/Avatar.svelte
+++ b/src/lib/components/Avatar.svelte
@@ -10,7 +10,12 @@
 
 <div class="author-content">
   <div class="author-avatar">
-    <img src={avatar.url} alt={name} width={avatar.width} height={avatar.height} />
+    <img
+      src={avatar.url}
+      alt={name}
+      width={avatar.width}
+      height={avatar.height}
+    />
   </div>
   <div class="author-profile">
     <h1 class="author-name">{name}</h1>

--- a/src/lib/components/Links.svelte
+++ b/src/lib/components/Links.svelte
@@ -13,7 +13,12 @@
   <ul class="link-list">
     {#each links as link}
       <li class="link-item">
-        <a href={link.url} title={link.name} target="_blank" rel="noopener noreferrer">
+        <a
+          href={link.url}
+          title={link.name}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           {#if link.name === "GitHub"}
             <Fa icon={faGithub} />
           {:else if link.name === "Twitter" || link.name === "X"}

--- a/src/lib/components/Links.svelte
+++ b/src/lib/components/Links.svelte
@@ -4,9 +4,9 @@
   import ZennLogo from "./ZennLogo.svelte";
   import HatenaLogo from "./HatenaLogo.svelte";
   import XLogo from "./XLogo.svelte";
-  import type { Link } from "$lib/types";
+  import type { SNSList } from "$lib/types";
 
-  export let links: Link[];
+  export let links: SNSList;
 </script>
 
 <div class="links">

--- a/src/lib/components/Links.test.ts
+++ b/src/lib/components/Links.test.ts
@@ -1,20 +1,28 @@
 import "@testing-library/jest-dom";
-import { test, expect } from "vitest";
+import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/svelte";
 import Links from "./Links.svelte";
-import type { Link } from "$lib/types";
+import type { SNSList } from "$lib/types";
 
 test("Links.svelte: shows site links from props", () => {
-  const links: Link[] = [
+  const links: SNSList = [
     {
       id: "aaa",
       name: "GitHub",
       url: "https://github.com/ryokryok",
+      createdAt: "2023-01-01T00:00:00.000Z",
+      updatedAt: "2023-01-01T00:00:00.000Z",
+      publishedAt: "2023-01-01T00:00:00.000Z",
+      revisedAt: "2023-01-01T00:00:00.000Z",
     },
     {
       id: "bbb",
       name: "X",
       url: "https://twitter.com/Mr_ozin",
+      createdAt: "2023-01-01T00:00:00.000Z",
+      updatedAt: "2023-01-01T00:00:00.000Z",
+      publishedAt: "2023-01-01T00:00:00.000Z",
+      revisedAt: "2023-01-01T00:00:00.000Z",
     },
   ];
   render(Links, { links: links });

--- a/src/lib/components/Projects.svelte
+++ b/src/lib/components/Projects.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import Fa from "svelte-fa";
   import { faExternalLink } from "@fortawesome/free-solid-svg-icons/faExternalLink";
-  import type { Project } from "$lib/types";
-  export let projects: Project[];
+  import type { ProjectList } from "$lib/types";
+  export let projects: ProjectList;
 </script>
 
 <div class="content-root">

--- a/src/lib/components/Projects.test.ts
+++ b/src/lib/components/Projects.test.ts
@@ -1,22 +1,30 @@
 import "@testing-library/jest-dom";
-import { test, expect } from "vitest";
-import { render, screen, getByRole, getByText } from "@testing-library/svelte";
+import { expect, test } from "vitest";
+import { getByRole, getByText, render, screen } from "@testing-library/svelte";
 import Projects from "./Projects.svelte";
-import type { Project } from "$lib/types";
+import type { ProjectList } from "$lib/types";
 
 test("Projects.svelte: show project description from props", () => {
-  const projects: Project[] = [
+  const projects: ProjectList = [
     {
       id: "1",
       title: "project-1",
       description: "description-1",
       url: "https://example.com/project-1",
+      createdAt: "2023-01-01T00:00:00.000Z",
+      updatedAt: "2023-01-01T00:00:00.000Z",
+      publishedAt: "2023-01-01T00:00:00.000Z",
+      revisedAt: "2023-01-01T00:00:00.000Z",
     },
     {
       id: "2",
       title: "project-2",
       description: "description-2",
       url: "https://example.com/project-2",
+      createdAt: "2023-01-01T00:00:00.000Z",
+      updatedAt: "2023-01-01T00:00:00.000Z",
+      publishedAt: "2023-01-01T00:00:00.000Z",
+      revisedAt: "2023-01-01T00:00:00.000Z",
     },
   ];
   render(Projects, { projects: projects });
@@ -24,13 +32,17 @@ test("Projects.svelte: show project description from props", () => {
   const projectElements = screen.getAllByRole("article");
   expect(projectElements.length).toBe(2);
 
-  expect(getByRole(projectElements[0], "heading")).toHaveTextContent("project-1");
+  expect(getByRole(projectElements[0], "heading")).toHaveTextContent(
+    "project-1",
+  );
   expect(getByText(projectElements[0], "description-1")).toBeInTheDocument();
   expect(getByRole<HTMLAnchorElement>(projectElements[0], "link").href).toBe(
     "https://example.com/project-1",
   );
 
-  expect(getByRole(projectElements[1], "heading")).toHaveTextContent("project-2");
+  expect(getByRole(projectElements[1], "heading")).toHaveTextContent(
+    "project-2",
+  );
   expect(getByText(projectElements[1], "description-2")).toBeInTheDocument();
   expect(getByRole<HTMLAnchorElement>(projectElements[1], "link").href).toBe(
     "https://example.com/project-2",

--- a/src/lib/server/fetchArticle.ts
+++ b/src/lib/server/fetchArticle.ts
@@ -13,7 +13,9 @@ if (import.meta.vitest) {
   const { it, expect } = import.meta.vitest;
   it("generateArticleURL", () => {
     const result = generateArticleURL();
-    expect(result).toBe("https://zenn.dev/api/articles?username=mr_ozin&count=6&order=latest");
+    expect(result).toBe(
+      "https://zenn.dev/api/articles?username=mr_ozin&count=6&order=latest",
+    );
   });
 }
 

--- a/src/lib/server/fetchProfile.ts
+++ b/src/lib/server/fetchProfile.ts
@@ -11,10 +11,11 @@ const apiKey = CMS_API_KEY ?? "";
 
 export const fetchProfile = async (): Promise<ProfileResponse> => {
   // use draftKey for development
+  const draftKey = dev
+    ? (await import("$env/static/private")).CMS_DRAFT_KEY
+    : "";
   const url = dev
-    ? `${baseURL}/profile?draftKey=${
-      (await import("$env/static/private")).CMS_DRAFT_KEY
-    }`
+    ? `${baseURL}/profile?draftKey=${draftKey}`
     : `${baseURL}/profile`;
   const res = await fetch(url, {
     headers: {

--- a/src/lib/server/fetchProfile.ts
+++ b/src/lib/server/fetchProfile.ts
@@ -1,4 +1,4 @@
-import { CMS_API_KEY, CMS_DRAFT_KEY, CMS_ENDPOINT } from "$env/static/private";
+import { CMS_API_KEY, CMS_ENDPOINT } from "$env/static/private";
 import { dev } from "$app/environment";
 import type {
   ProfileResponse,
@@ -8,11 +8,13 @@ import type {
 
 const baseURL = CMS_ENDPOINT ?? "";
 const apiKey = CMS_API_KEY ?? "";
-const draftKey = CMS_DRAFT_KEY ?? "";
 
 export const fetchProfile = async (): Promise<ProfileResponse> => {
+  // use draftKey for development
   const url = dev
-    ? `${baseURL}/profile?draftKey=${draftKey}`
+    ? `${baseURL}/profile?draftKey=${
+      (await import("$env/static/private")).CMS_DRAFT_KEY
+    }`
     : `${baseURL}/profile`;
   const res = await fetch(url, {
     headers: {

--- a/src/lib/server/fetchProfile.ts
+++ b/src/lib/server/fetchProfile.ts
@@ -1,11 +1,42 @@
-import { CMS_API_KEY, CMS_ENDPOINT } from "$env/static/private";
-import type { ProfileResponse } from "$lib/types";
+import { CMS_API_KEY, CMS_DRAFT_KEY, CMS_ENDPOINT } from "$env/static/private";
+import { dev } from "$app/environment";
+import type {
+  ProfileResponse,
+  ProjectsResponse,
+  SNSResponse,
+} from "$lib/types";
 
 const baseURL = CMS_ENDPOINT ?? "";
 const apiKey = CMS_API_KEY ?? "";
+const draftKey = CMS_DRAFT_KEY ?? "";
 
 export const fetchProfile = async (): Promise<ProfileResponse> => {
-  const res = await fetch(`${baseURL}/profile`, {
+  const url = dev
+    ? `${baseURL}/profile?draftKey=${draftKey}`
+    : `${baseURL}/profile`;
+  const res = await fetch(url, {
+    headers: {
+      "X-MICROCMS-API-KEY": apiKey,
+    },
+  });
+
+  return await res.json();
+};
+
+export const fetchSNS = async (): Promise<SNSResponse> => {
+  const url = `${baseURL}/sns`;
+  const res = await fetch(url, {
+    headers: {
+      "X-MICROCMS-API-KEY": apiKey,
+    },
+  });
+
+  return await res.json();
+};
+
+export const fetchProjects = async (): Promise<ProjectsResponse> => {
+  const url = `${baseURL}/projects`;
+  const res = await fetch(url, {
     headers: {
       "X-MICROCMS-API-KEY": apiKey,
     },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,13 +8,13 @@ export type Avatar = {
   };
 };
 
-export type Link = {
+type Link = {
   id: string;
   name: string;
   url: string;
 };
 
-export type Project = {
+type Project = {
   id: string;
   title: string;
   description: string;
@@ -28,11 +28,24 @@ type MicroCMSDate = {
   revisedAt: string;
 };
 
-export type ProfileResponse = MicroCMSDate &
-  Avatar & {
-    sns: Link[];
-    projects: Project[];
-  };
+type MicroCMSListData<T> = {
+  contents: (T & MicroCMSDate)[];
+  totalCount: number;
+  offset: number;
+  limit: number;
+};
+
+export type ProfileResponse =
+  & MicroCMSDate
+  & Avatar;
+
+export type SNSResponse = MicroCMSListData<Link>;
+
+export type SNSList = SNSResponse["contents"];
+
+export type ProjectsResponse = MicroCMSListData<Project>;
+
+export type ProjectList = ProjectsResponse["contents"];
 
 export type ZennArticle = {
   id: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,9 +35,7 @@ type MicroCMSListData<T> = {
   limit: number;
 };
 
-export type ProfileResponse =
-  & MicroCMSDate
-  & Avatar;
+export type ProfileResponse = MicroCMSDate & Avatar;
 
 export type SNSResponse = MicroCMSListData<Link>;
 

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,15 +1,26 @@
 import { error } from "@sveltejs/kit";
 
 import type { PageServerLoad } from "./$types";
-import { fetchProfile } from "$lib/server/fetchProfile";
+import {
+  fetchProfile,
+  fetchProjects,
+  fetchSNS,
+} from "$lib/server/fetchProfile";
 import { fetchArticle } from "$lib/server/fetchArticle";
 
 export const load: PageServerLoad = async () => {
   try {
-    const profileResponse = await fetchProfile();
-    const articlesResponse = await fetchArticle();
-    if (profileResponse || articlesResponse) {
-      return { profile: profileResponse, articles: articlesResponse.articles };
+    const profile = await fetchProfile();
+    const sns = await fetchSNS();
+    const projects = await fetchProjects();
+    const { articles } = await fetchArticle();
+    if (profile && sns && projects) {
+      return {
+        profile,
+        sns,
+        projects,
+        articles,
+      };
     } else {
       throw error(404, "Not found");
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,8 +33,9 @@
 
   :global(body, h1, h2, h3, h4, h5, h6, p, ol, ul) {
     font-weight: normal;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-      Cantarell, "Open Sans", "Helvetica Neue", "sans-serif";
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+      Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
+      "sans-serif";
   }
 
   :global(ol, ul) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,9 +15,9 @@
     avatar={data.profile.avatar}
   />
 
-  <Links links={data.profile.sns} />
+  <Links links={data.sns.contents} />
 
-  <Projects projects={data.profile.projects} />
+  <Projects projects={data.projects.contents} />
 
   <Articles articles={data.articles} />
 </div>


### PR DESCRIPTION
### Changes

- MicroCMSにて、まとめて1つのエンドポイントで複数の投稿情報をとってくるようにしていたのをやめて、それぞれ別個に投稿情報を取得することにした
- 投稿情報が、他の投稿情報に依存していたが、それをやめた
  - Profileの投稿情報に、SNSやProjectを紐づけていたが、Projectを追加するときにProfileも更新する必要があり、二度手間だった
  - この変更で上記の二度手間がなくなっった

### Todo

下書きプレビュー時のデータ取得、ドラフトキーの取り扱い